### PR TITLE
Update to V11 and various additions

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -115,7 +115,7 @@ function plugin_ticketcleaner_install() {
                 `lastupdate` VARCHAR(50) NULL,
                 PRIMARY KEY (`id`)
             )
-            COLLATE='utf8_general_ci'
+            COLLATE='utf8mb4_general_ci'
             ENGINE=InnoDB;
             ";
 
@@ -130,7 +130,7 @@ function plugin_ticketcleaner_install() {
                 PRIMARY KEY (`id`),
                 INDEX `hash` (`hash`)
             )
-            COLLATE='utf8_general_ci'
+            COLLATE='utf8mb4_general_ci'
             ENGINE=InnoDB;
             ";
 
@@ -166,7 +166,7 @@ function plugin_ticketcleaner_install() {
                       INDEX `type` (`type`),
                      INDEX `order` (`order`)
                   )
-                  COLLATE='utf8_general_ci'
+                  COLLATE='utf8mb4_general_ci'
                   ENGINE=InnoDB
                   ;";
 
@@ -424,4 +424,5 @@ class PluginTicketCleaner {
    }
 
 }
+
 

--- a/hook.php
+++ b/hook.php
@@ -67,7 +67,7 @@ function loadSha1IntoDB() {
    $datetime = date( "YmdHis", $stats['mtime'] );
 
    if ($datetime > $lastupdate) { // means picture folder has been modified since last update
-      $DB->query("TRUNCATE TABLE glpi_plugin_ticketcleaner_picturehashes"); //or die("error on 'truncate' glpi_plugin_ticketcleaner_picturehashes ". $DB->error()) ;
+      $DB->doQuery("TRUNCATE TABLE glpi_plugin_ticketcleaner_picturehashes"); //or die("error on 'truncate' glpi_plugin_ticketcleaner_picturehashes ". $DB->error()) ;
       // compute hash for each file and then insert it in DB with REPLACE INTO to prvent double entries
       foreach ($files as $pict) {
          if ($pict <> "." && $pict <> "..") {
@@ -119,7 +119,7 @@ function plugin_ticketcleaner_install() {
             ENGINE=InnoDB;
             ";
 
-      $DB->query($query) or die("error creating glpi_plugin_ticketcleaner_picturehashes_lastupdate " . $DB->error());
+      $DB->doQuery($query) or die("error creating glpi_plugin_ticketcleaner_picturehashes_lastupdate " . $DB->error());
    }
 
    if (!$DB->tableExists("glpi_plugin_ticketcleaner_picturehashes")) {
@@ -134,20 +134,20 @@ function plugin_ticketcleaner_install() {
             ENGINE=InnoDB;
             ";
 
-      $DB->query($query) or die("error creating glpi_plugin_ticketcleaner_picturehashes " . $DB->error());
+      $DB->doQuery($query) or die("error creating glpi_plugin_ticketcleaner_picturehashes " . $DB->error());
    }
 
    loadSha1IntoDB(); // also done on the fly
 
    if ($DB->tableExists("backup_glpi_plugin_ticketcleaner_filters")) {
       $query = "DROP TABLE `backup_glpi_plugin_ticketcleaner_filters`;";
-      $DB->query($query) or die("error droping old backup_glpi_plugin_ticketcleaner_filters" . $DB->error());
+      $DB->doQuery($query) or die("error droping old backup_glpi_plugin_ticketcleaner_filters" . $DB->error());
    }
 
    if ($DB->tableExists("glpi_plugin_ticketcleaner_filters") && $DB->fieldExists( 'glpi_plugin_ticketcleaner_filters', 'filter' )) {
 
       $query = "RENAME TABLE `glpi_plugin_ticketcleaner_filters` TO `backup_glpi_plugin_ticketcleaner_filters`;";
-      $DB->query($query) or die("error renaming glpi_plugin_ticketcleaner_filters to backup_glpi_plugin_ticketcleaner_filters" . $DB->error());
+      $DB->doQuery($query) or die("error renaming glpi_plugin_ticketcleaner_filters to backup_glpi_plugin_ticketcleaner_filters" . $DB->error());
    }
 
    if (!$DB->tableExists("glpi_plugin_ticketcleaner_filters")) {
@@ -170,7 +170,7 @@ function plugin_ticketcleaner_install() {
                   ENGINE=InnoDB
                   ;";
 
-      $DB->query($query) or die("error creating glpi_plugin_ticketcleaner_filters " . $DB->error());
+      $DB->doQuery($query) or die("error creating glpi_plugin_ticketcleaner_filters " . $DB->error());
 
    } else {
       // change regex and replacement field type
@@ -180,13 +180,13 @@ function plugin_ticketcleaner_install() {
          $query = "ALTER TABLE `glpi_plugin_ticketcleaner_filters`
                   ALTER `regex` DROP DEFAULT,
                   ALTER `replacement` DROP DEFAULT;";
-         $DB->query($query) or die("error droping defaults for 'regex' and 'replacement' in glpi_plugin_ticketcleaner_filters " . $DB->error());
+         $DB->doQuery($query) or die("error droping defaults for 'regex' and 'replacement' in glpi_plugin_ticketcleaner_filters " . $DB->error());
 
          $query = "ALTER TABLE `glpi_plugin_ticketcleaner_filters`
                   CHANGE COLUMN `order` `order` INT(11) NULL AFTER `type` ,
                   CHANGE COLUMN `regex` `regex` TEXT NOT NULL AFTER `order` ,
                   CHANGE COLUMN `replacement` `replacement` TEXT NOT NULL AFTER `regex`;";
-         $DB->query($query) or die("error changing type of 'regex' and 'replacement' in glpi_plugin_ticketcleaner_filters " . $DB->error());
+         $DB->doQuery($query) or die("error changing type of 'regex' and 'replacement' in glpi_plugin_ticketcleaner_filters " . $DB->error());
 
       }
    }
@@ -207,12 +207,12 @@ function plugin_ticketcleaner_uninstall() {
    // Current version tables
    if ($DB->tableExists("glpi_plugin_ticketcleaner_picturehashes")) {
       $query = "DROP TABLE `glpi_plugin_ticketcleaner_picturehashes`";
-      $DB->query($query) or die("error deleting glpi_plugin_ticketcleaner_picturehashes");
+      $DB->doQuery($query) or die("error deleting glpi_plugin_ticketcleaner_picturehashes");
    }
 
    if ($DB->tableExists("glpi_plugin_ticketcleaner_picturehashes_lastupdate")) {
       $query = "DROP TABLE `glpi_plugin_ticketcleaner_picturehashes_lastupdate`";
-      $DB->query($query) or die("error deleting glpi_plugin_ticketcleaner_picturehashes_lastupdate");
+      $DB->doQuery($query) or die("error deleting glpi_plugin_ticketcleaner_picturehashes_lastupdate");
    }
 
    return true;
@@ -424,3 +424,4 @@ class PluginTicketCleaner {
    }
 
 }
+

--- a/inc/filter.class.php
+++ b/inc/filter.class.php
@@ -335,7 +335,7 @@ class PluginTicketcleanerFilter extends CommonDBTM {
 
       echo "<tr class='tab_bg_1'>";
       echo "<td >".__('Order', 'ticketcleaner')."&nbsp;:</td>";
-      echo "<td><input type='text' size='10' maxlength=10 name='order' value='".$this->fields["order"]."'></td>";
+      echo "<td><input type='text' size='10' maxlength=10 name='order' value='".$this->fields["order"]."' required></td>";
       echo "</tr>";
 
       echo "<tr class='tab_bg_1'>";
@@ -366,4 +366,5 @@ class PluginTicketcleanerFilter extends CommonDBTM {
    }
 
 }
+
 

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -43,6 +43,7 @@ class PluginTicketcleanerMenu extends CommonGLPI {
       $menu = [];
       $menu['title'] = self::getMenuName();
       $menu['page']  = "$front_page/filter.php";
+      $menu['icon'] = 'fa-solid fa-broom';
 
       $itemtypes = ['PluginTicketcleanerFilter' => 'ticketcleanerfilter'];
 
@@ -67,3 +68,4 @@ class PluginTicketcleanerMenu extends CommonGLPI {
 
 
 }
+

--- a/setup.php
+++ b/setup.php
@@ -35,7 +35,7 @@ along with this plugin. If not, see <http://www.gnu.org/licenses/>.
 //                  and it cleans attached pictures to emails
 //                  It has been succesfully tested with plain TEXT and HTML emails
 // ----------------------------------------------------------------------
-define ("PLUGIN_TICKETCLEANER_VERSION", "4.0.3");
+define ("PLUGIN_TICKETCLEANER_VERSION", "5.0.0");
 define ("PLUGIN_TICKETCLEANER_VERSION_MIN", "11.0");
 define ("PLUGIN_TICKETCLEANER_VERSION_MAX", "12.0");
 
@@ -116,4 +116,5 @@ function plugin_ticketcleaner_check_prerequisites() {
 function plugin_ticketcleaner_check_config() {
    return true;
 }
+
 

--- a/setup.php
+++ b/setup.php
@@ -36,8 +36,8 @@ along with this plugin. If not, see <http://www.gnu.org/licenses/>.
 //                  It has been succesfully tested with plain TEXT and HTML emails
 // ----------------------------------------------------------------------
 define ("PLUGIN_TICKETCLEANER_VERSION", "4.0.3");
-define ("PLUGIN_TICKETCLEANER_VERSION_MIN", "10.0");
-define ("PLUGIN_TICKETCLEANER_VERSION_MAX", "11.0");
+define ("PLUGIN_TICKETCLEANER_VERSION_MIN", "11.0");
+define ("PLUGIN_TICKETCLEANER_VERSION_MAX", "12.0");
 
 /**
  * Summary of plugin_init_ticketcleaner
@@ -116,3 +116,4 @@ function plugin_ticketcleaner_check_prerequisites() {
 function plugin_ticketcleaner_check_config() {
    return true;
 }
+


### PR DESCRIPTION
Hello,

I've made several changes to get it up and running on V11, but also added some things to improve it. I hope you dont mind the additional things i did. If you do, let me know, and i'll make a PR just for the core functionality.
- changed `$DB->query` to `$DB->doQuery`, needed for V11 functionality
- changed version requirements, needed for V11 functionality
- changed collation from `utf8_general_ci` to `utf8mb4_general_ci`, i was getting warnings in php-errors.log about it
- marked the order field as required, as trying to save with it being empty caused an error, and this was the easiest fix i could think of
- added a broom icon in front of the menu selection, so it lines up properly with the rest